### PR TITLE
Add chained selectors for avatar images

### DIFF
--- a/foundations/intro-to-css/04-chaining-selectors/style.css
+++ b/foundations/intro-to-css/04-chaining-selectors/style.css
@@ -1,1 +1,8 @@
-/* Add CSS Styling */
+.avatar.proportioned {
+    width: 300px;
+}
+
+.avatar.distorted {
+    width: 200px;
+    height: 400px;
+}


### PR DESCRIPTION
Description

- This PR implements CSS rules using chained class selectors to apply unique styles to two images that share a base class.
- Applied styles to avatar.proportioned so it is 300px wide and retains square proportions.
- Applied styles to avatar.distorted so it is 200px wide with a fixed height of 400px, producing a distorted effect.
- Demonstrates the use of chaining selectors to target elements with multiple classes.

Checklist

- [ ]  Properly chained class selectors for each rule
- [ ]  proportioned image maintains original square proportions
- [ ]  distorted image appears stretched as expected
- [ ]  Matches the desired outcome image