### PR TITLE
style(full-page): Align a full page with flexbox

### DIFF
--- a/foundations/flex/06-flex-layout/style.css
+++ b/foundations/flex/06-flex-layout/style.css
@@ -5,6 +5,10 @@ body {
   margin: 0;
   overflow: hidden;
   font-family: Roboto, sans-serif;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  
 }
 
 img {
@@ -16,6 +20,7 @@ button {
   border: none;
   border-radius: 8px;
   background: #eee;
+  padding:8px;
 }
 
 input {
@@ -24,3 +29,42 @@ input {
   padding: 8px 24px;
   width: 400px;
 }
+
+ul {
+  padding: 0px 16px;
+  gap: 16px;
+}
+
+a {
+  text-decoration: none;
+  color: #808080;
+}
+
+.header,
+.footer {
+  display: flex;
+  justify-content: space-between;
+  
+}
+
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.footer {
+  background-color: #eee;
+}
+
+.left-links,
+.right-links {
+  display: flex;
+  list-style: none;
+}
+
+
+
+
+


### PR DESCRIPTION
### Summary
Aligned a full page worth of elements using flexbox, gaps and padding.

### Changes
- Space out header, content, and footer
- Added padding to buttons
- Added padding and gap to list items and removed bullet points
- Removed underlining from anchor tags
- Pushed header and footer items to opposite sides of body
- Aligned the content items centrally in the horizontal direction
- Added gaps between the content items

### Checks
- [x] The header is at the top of the page, the footer is at the bottom, and they stay in place if you resize your screen.
- [x] The header and footer have padding.
- [x] The links in the header and footer are pushed to either side.
- [x] There is space between the links in the header and footer.
- [x] The footer has a light gray background (`#eeeeee`).
- [x] The logo, input and buttons are centered in the screen.
- [x] The buttons have an appropriate amount of padding.
- [x] There is space between the logo, input and buttons.
- [x] The CSS passes W3C validation

## Before
![flex-ex5-before](https://github.com/user-attachments/assets/5aad4d16-efff-4a09-897f-5117b6571a24)

## After
<img width="2878" height="1798" alt="image" src="https://github.com/user-attachments/assets/752d2b77-bc86-47bd-bab9-6bc1f5bbf59e" />